### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,28 +12,28 @@ CMRI	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-set_address   KEYWORD2
-set_length    KEYWORD2
-process       KEYWORD2
-process_char  KEYWORD2
-transmit      KEYWORD2
-get_bit       KEYWORD2
-get_byte      KEYWORD2
-set_bit       KEYWORD2
-set_byte      KEYWORD2
-decode        KEYWORD2
-valid         KEYWORD2
-packet_type   KEYWORD2
+set_address	KEYWORD2
+set_length	KEYWORD2
+process	KEYWORD2
+process_char	KEYWORD2
+transmit	KEYWORD2
+get_bit	KEYWORD2
+get_byte	KEYWORD2
+set_bit	KEYWORD2
+set_byte	KEYWORD2
+decode	KEYWORD2
+valid	KEYWORD2
+packet_type	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-MAX  LITERAL1
-INIT LITERAL1
-SET  LITERAL1
-GET  LITERAL1
-POLL LITERAL1
-STX  LITERAL1
-ETX  LITERAL1
+MAX	LITERAL1
+INIT	LITERAL1
+SET	LITERAL1
+GET	LITERAL1
+POLL	LITERAL1
+STX	LITERAL1
+ETX	LITERAL1
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords