### PR TITLE
Changing process() method return type to char - issue #11

### DIFF
--- a/CMRI.cpp
+++ b/CMRI.cpp
@@ -58,16 +58,18 @@ void CMRI::set_address(unsigned int address)
 // reads in serial data, decodes packets
 // automatically responds to POLL requests
 // returns packet type so if we got a SET request you know to update your outputs
-bool CMRI::process()
+char CMRI::process()
 {
+	_ret_mode = NOOP;
 	while (_serial.available() > 0)
 	{
 		if (process_char(_serial.read()))
 		{
-			return true;
+			return _ret_mode;
 		}
 	}
-	return false;
+
+	return _ret_mode;
 }
 
 bool CMRI::process_char(char c)
@@ -80,12 +82,15 @@ bool CMRI::process_char(char c)
 	{
 		case POLL:
 			transmit();
+			_ret_mode = POLL;
 			return true;
 		
 		case SET:
+			_ret_mode = SET;
 			return true;
 		
 		default:
+			_ret_mode = NOOP;
 			return false;
 	}
 }

--- a/CMRI.h
+++ b/CMRI.h
@@ -34,8 +34,8 @@ class CMRI
 	public:
 		CMRI(unsigned int address = 0, unsigned int input_bits = 24, unsigned int output_bits = 48, Stream& serial_class = Serial);
 		void set_address(unsigned int address);
-		
-		bool process();
+		char mode;
+		char process();
 		bool process_char(char c);
 		void transmit();
 		
@@ -72,6 +72,8 @@ private:
 		// parsing state variables
 		int     _mode;
 		int     _rx_index;
+		
+		char	_ret_mode;
 		
 		uint8_t    _decode(uint8_t c); // process one character received from serial port
 };


### PR DESCRIPTION
Code is advertised to return char type from process() method but clearly is written to return bool instead. This fixes that. 