### PR TITLE
Update CMRI.cpp to change the delay duration in transmit()

### DIFF
--- a/CMRI.cpp
+++ b/CMRI.cpp
@@ -139,7 +139,8 @@ bool CMRI::set_byte(int pos, char b)
 
 void CMRI::transmit()
 {
-	delay(50); // tiny delay to let things recover
+	// delay(50); // tiny delay to let things recover
+	delayMicroseconds(50); //a minscule delay to let things recover
 	_serial.write(255);
 	_serial.write(255);
 	_serial.write(STX);

--- a/CMRI.cpp
+++ b/CMRI.cpp
@@ -139,7 +139,6 @@ bool CMRI::set_byte(int pos, char b)
 
 void CMRI::transmit()
 {
-	// delay(50); // tiny delay to let things recover
 	delayMicroseconds(50); //a minscule delay to let things recover
 	_serial.write(255);
 	_serial.write(255);


### PR DESCRIPTION
Resolves #14 

When polling a number of nodes, or one node with many IIO bits, poll times can be in excess of 150ms per node. 

This has been tested with `delayMicroseconds(50)` on a single node with 416 IO bits and dropped the poll time from 95-85ms to 39-42ms 

