### PR TITLE
Fix set_bit() boundary check

### DIFF
--- a/CMRI.cpp
+++ b/CMRI.cpp
@@ -112,7 +112,7 @@ char CMRI::get_byte(int pos)
 
 bool CMRI::set_bit(int pos, bool bit)
 {
-	if ((pos + 7) / 8 >= _tx_length)
+	if (pos / 8 >= _tx_length)
 		return false; // out of bounds
 	else
 	{


### PR DESCRIPTION
## Summary

- Fix off-by-one error in `set_bit()` boundary check that incorrectly rejected the last 7 bits of the transmit buffer
- The original check `(pos + 7) / 8 >= _tx_length` falsely rejected valid bit positions at the end of each byte boundary
- Changed to correct check: `pos / 8 >= _tx_length`

## Details

**Problem:** For a buffer with `_tx_length = N` bytes (valid bits 0 to `8N-1`):
- `set_bit(8N-1, ...)` → `(8N-1+7)/8 = N` → `N >= N` → falsely returns `false`
- The last 7 bits of every buffer were incorrectly treated as out of bounds

**Fix:** Use the same boundary check as `get_bit()` (which uses `get_byte()` correctly)

**Example:** With 1-byte output buffer (bits 0-7):
- Before: `set_bit(7, true)` returned `false` (broken)
- After: `set_bit(7, true)` returns `true` (correct)

Closes #17 