### PR TITLE
Fix missing STX (0x02) DLE-escape in transmit()

### DIFF
--- a/src/CMRI.cpp
+++ b/src/CMRI.cpp
@@ -143,10 +143,9 @@ void CMRI::transmit()
 	_serial.write(GET);
 	for (int i = 0; i < _tx_length; i++)
 	{
-		if (_tx_buffer[i] == ETX)
-			_serial.write(ESC); // escape because this looks like an STX bit (very basic protocol)
-		if (_tx_buffer[i] == ESC)
-			_serial.write(ESC); // escape because this looks like an escape bit (very basic protocol)
+		// DLE-escape STX, ETX and DLE characters
+		if (_tx_buffer[i] == STX || _tx_buffer[i] == ETX || _tx_buffer[i] == ESC)
+			_serial.write(ESC);
 		_serial.write(_tx_buffer[i]);
 	}
 	_serial.write(ETX);

--- a/test/test_cmri/test_main.cpp
+++ b/test/test_cmri/test_main.cpp
@@ -61,9 +61,11 @@ void test_set_bit_reflected_in_transmit(void)
 	cmri.transmit();
 
 	// Frame: FF FF STX 'A' GET <3 data bytes> ETX
-	TEST_ASSERT_EQUAL_UINT8(0x01, s.tx[5]); // byte 0, bit 0
-	TEST_ASSERT_EQUAL_UINT8(0x02, s.tx[6]); // byte 1, bit 1
-	TEST_ASSERT_EQUAL_UINT8(0x00, s.tx[7]);
+	// byte 1 = 0x02 (STX), so it gets DLE-escaped to ESC 0x02
+	TEST_ASSERT_EQUAL_UINT8(0x01, s.tx[5]);      // byte 0, bit 0
+	TEST_ASSERT_EQUAL_UINT8(CMRI::ESC, s.tx[6]); // DLE escape for byte 1 (STX value)
+	TEST_ASSERT_EQUAL_UINT8(0x02, s.tx[7]);      // byte 1, bit 1
+	TEST_ASSERT_EQUAL_UINT8(0x00, s.tx[8]);      // byte 2
 }
 
 // Regression for the set_bit() bounds bug: the old (pos + 7) / 8 check wrongly
@@ -154,7 +156,7 @@ void test_address_filtering(void)
 	TEST_ASSERT_EQUAL_UINT8(0, cmri.get_byte(0));
 }
 
-// Data bytes that collide with ETX/ESC are escaped in the transmitted frame.
+// Data bytes that collide with STX, ETX or ESC are escaped in the transmitted frame.
 void test_transmit_escapes_control_bytes(void)
 {
 	Stream s;


### PR DESCRIPTION
## Summary

-   Fix missing DLE escape for STX (0x02) in `transmit()` per NMRA CMRInet spec LCS-9.10.1 v1.1
-   The spec requires DLE (0x10) to be inserted before any data byte equal to STX (0x02), ETX (0x03), or DLE (0x10) in the message body
-   The current code only escapes ETX and DLE — an output data byte of 0x02 is sent raw, and the host (JMRI) may misinterpret it as start-of-text, breaking packet synchronization
-   Also fixes a misleading comment

## Details

**Problem:** The NMRA CMRInet specification (LCS-9.10.1, §Data Link Escape (DLE) Processing) requires:

> "Software must insert a DLE in front of any of these data values when forming a Transmit Data or Receive Data message."

The three values requiring DLE are STX (0x02), ETX (0x03), and DLE (0x10).

The current `transmit()` only checks two of the three:

```cpp
if (_tx_buffer[i] == ETX)
    _serial.write(ESC);
if (_tx_buffer[i] == ESC)
    _serial.write(ESC);
_serial.write(_tx_buffer[i]);
```

STX (0x02) is not escaped. If any output data byte carries the value 0x02 (perfectly valid binary data), it is transmitted raw. A CMRInet host receiving this frame will see 0x02 in the data stream and interpret it as the start-of-text character, potentially corrupting the current frame and subsequent ones.

**Fix:** Combine the escape check into a single condition covering all three protocol character values (STX, ETX, DLE). The `ESC` constant in the code is already defined as 0x10 (DLE).


## Changes

`CMRI.cpp` — `transmit()` method:

```diff
 	for (int i=0; i<_tx_length; i++)
 	{
		if (_tx_buffer[i] == STX || _tx_buffer[i] == ETX || _tx_buffer[i] == ESC)
			_serial.write(ESC);
 		_serial.write(_tx_buffer[i]);
 	}
```

Closes #18 