### PR TITLE
Handle INIT messages and add set_init_handler() callback

### DIFF
--- a/examples/init_handler/init_handler.ino
+++ b/examples/init_handler/init_handler.ino
@@ -1,0 +1,81 @@
+/**
+ * C/MRI INIT handler example
+ * ===========================
+ * Demonstrates how to register an INIT callback to inspect the
+ * configuration payload sent by JMRI at startup.
+ *
+ * The INIT message body follows NMRA LCS-9.10.1:
+ *   byte 0:   NDP (Node Definition Parameter)
+ *   bytes 1-2: DLH/DLL (transmit delay, high & low bytes)
+ *   bytes 3+:  node-type-specific options
+ *
+ * The transmit delay is computed as (DLH * 256 + DLL) * 10 microseconds.
+ * This example reads the delay and prints the configuration to Serial.
+ *
+ * To set up in JMRI:
+ * 1: Create a new C/MRI connection (Serial, 9600 baud)
+ * 2: Configure a node with address 0 — JMRI sends an INIT at startup
+ * 3: Open Tools > Tables > Lights and add a light at address 1
+ * 4: Open the C/MRI Monitor to watch the INIT message
+ *    Raw format: [41 49 43 00 0A ...] = UA 'A', cmd 'I', NDP='C', DL=10
+ */
+
+#include <CMRI.h>
+
+CMRI cmri; // defaults to a SMINI with address 0
+
+// ---------------------------------------------------------------------------
+// INIT handler callback
+// Called automatically when an INIT ('I') packet is received.
+// data  – pointer to the raw INIT payload bytes
+// len   – number of bytes in the payload
+// ---------------------------------------------------------------------------
+void on_init(const uint8_t *data, int len)
+{
+	Serial.print(F("INIT received ("));
+
+	if (len >= 1)
+	{
+		Serial.print(F("NDP="));
+		Serial.write(data[0]);
+		Serial.print(F(" "));
+	}
+
+	if (len >= 3)
+	{
+		int delay_us = (data[1] * 256 + data[2]) * 10;
+		Serial.print(F("DL="));
+		Serial.print(delay_us);
+		Serial.print(F("us "));
+	}
+
+	if (len > 3)
+	{
+		Serial.print(F("options="));
+		for (int i = 3; i < len; i++)
+		{
+			if (i > 3)
+				Serial.print(F(" "));
+			if (data[i] < 16)
+				Serial.print(F("0"));
+			Serial.print(data[i], HEX);
+		}
+		Serial.print(F(" "));
+	}
+
+	Serial.print(len);
+	Serial.println(F(" bytes"));
+}
+
+void setup()
+{
+	Serial.begin(9600, SERIAL_8N2);
+	cmri.set_init_handler(on_init);
+	pinMode(13, OUTPUT);
+}
+
+void loop()
+{
+	cmri.process();
+	digitalWrite(13, cmri.get_bit(0));
+}

--- a/src/CMRI.cpp
+++ b/src/CMRI.cpp
@@ -39,7 +39,7 @@ CMRI::CMRI(unsigned int address, unsigned int input_bits, unsigned int output_bi
 
       // parsing state
       ,
-      _mode(PREAMBLE_1), _rx_index(0)
+      _mode(PREAMBLE_1), _rx_index(0), _rx_data_len(0), _init_handler(nullptr)
 
 {
 	// clear to zero
@@ -52,6 +52,11 @@ CMRI::CMRI(unsigned int address, unsigned int input_bits, unsigned int output_bi
 void CMRI::set_address(unsigned int address)
 {
 	_address = address;
+}
+
+void CMRI::set_init_handler(void (*handler)(const uint8_t *, int))
+{
+	_init_handler = handler;
 }
 
 // reads in serial data, decodes packets
@@ -71,17 +76,21 @@ bool CMRI::process()
 
 bool CMRI::process_char(char c)
 {
-	// if it's a SET that's fine do nothing
-	// if it's an INIT that's also fine, we don't really care
-	// if it's a GET, well, do nothing since it must be someone else replying
-	// if it's a POLL then reply straight away with our data
-	switch (_decode(c))
+	// if it's a SET, update the output buffer
+	// if it's an INIT, the payload was consumed and the sketch can handle it
+	// if it's a GET, ignore — must be another node replying
+	// if it's a POLL, reply straight away with our input data
+	unsigned char ret = _decode(c);
+	switch (ret)
 	{
 	case POLL:
 		transmit();
 		return true;
 
 	case SET:
+	case INIT:
+		if (ret == INIT && _init_handler)
+			_init_handler((const uint8_t *)_rx_buffer, _rx_data_len);
 		return true;
 
 	default:
@@ -188,7 +197,10 @@ uint8_t CMRI::_decode(uint8_t c)
 		break;
 
 	case DECODE_CMD:
+		_rx_packet_type = c;
 		if (c == SET)
+			_mode = DECODE_DATA;
+		else if (c == INIT)
 			_mode = DECODE_DATA;
 		else if (c == POLL)
 			goto POSTAMBLE_POLL;
@@ -239,8 +251,10 @@ uint8_t CMRI::_decode(uint8_t c)
 	return NOOP;
 
 POSTAMBLE_SET:
+	_rx_data_len = _rx_index;
 	_mode = PREAMBLE_1;
-	return SET;
+	_rx_index = 0;
+	return _rx_packet_type;
 
 POSTAMBLE_POLL:
 	_mode = PREAMBLE_1;

--- a/src/CMRI.h
+++ b/src/CMRI.h
@@ -34,6 +34,7 @@ class CMRI
   public:
 	CMRI(unsigned int address = 0, unsigned int input_bits = 24, unsigned int output_bits = 48, Stream &serial_class = Serial);
 	void set_address(unsigned int address);
+	void set_init_handler(void (*handler)(const uint8_t *data, int len));
 
 	bool process();
 	bool process_char(char c);
@@ -82,6 +83,8 @@ class CMRI
 	char _rx_packet_type;
 	char *_rx_buffer;
 	char *_tx_buffer;
+	int _rx_data_len;
+	void (*_init_handler)(const uint8_t *, int);
 
 	Stream &_serial;
 


### PR DESCRIPTION
Route INIT ('I') packets through the data decoder and expose the configuration payload to sketches via an optional callback.

## Summary

NMRA CMRInet (LCS-9.10.1) defines four message types: Init (`I`), Poll (`P`), Transmit Data / SET (`T`), and Receive Data / GET (`R`).
The Init message is the first message sent to a node after power-up, carrying configuration data such as the node type, transmit character delay, and card layout.
Previously the library had two problems:
1. Init messages were silently discarded — the payload bytes were not consumed from the serial buffer, potentially corrupting the next frame
2. Even with the payload captured, sketches had no way to access it.

This PR fixes both: Init payloads are decoded and stored, and a
callback mechanism lets the sketch inspect NDP, delay, and option bytes.

## Changes

### Init message handling (`_decode`)

Treat `I` the same as `T` in `DECODE_CMD` — enter `DECODE_DATA` to consume the payload bytes (with DLE un-escaping) until ETX. The existing (unused) `_rx_packet_type` member stores the current command type, so `POSTAMBLE_SET` returns either `SET` or `INIT` to the caller.

### `void set_init_handler(void (*handler)(const uint8_t *data, int len))`

Registers a callback that fires on every complete INIT packet.
| Parameter | Description                         |
|-----------|-------------------------------------|
| `data`    | Pointer to the raw INIT payload     |
| `len`     | Number of bytes in the payload      |

### INIT payload format (NMRA LCS-9.10.1)

| Offset | Field   | Description                               |
|--------|---------|-------------------------------------------|
| 0      | NDP     | Node Definition Parameter (e.g. `C`)      |
| 1      | DLH     | Transmit delay high byte                  |
| 2      | DLL     | Transmit delay low byte                   |
| 3+     | Options | Node-type-specific configuration bytes    |
Delay = `(DLH * 256 + DLL) * 10` microseconds

### Internal changes

- `_rx_packet_type` is now written during `DECODE_CMD` (repurposed from its previous unused declaration)
- `_rx_data_len` tracks the actual number of payload bytes received (saved in `POSTAMBLE_SET` before resetting `_rx_index`)
- `_init_handler` function pointer, default `nullptr` (no overhead when unused)
- Callback fires inside `process_char()` when `_decode()` returns `INIT`
- `process_char()` returns `true` for INIT messages (consistent with SET)

No memory allocation, no extra includes, no performance impact when no handler is registered.

## Example

```cpp
void on_init(const uint8_t *data, int len) {
  Serial.print(F("INIT received ("));
  // ...
}
void setup() {
  cmri.set_init_handler(on_init);
}
```

See examples/init_handler/init_handler.ino for the full example.

Closes #20