### PR TITLE
Return packet type processed in process()

### DIFF
--- a/src/CMRI.cpp
+++ b/src/CMRI.cpp
@@ -61,17 +61,19 @@ void CMRI::set_init_handler(void (*handler)(const uint8_t *, int))
 
 // reads in serial data, decodes packets
 // automatically responds to POLL requests
-// returns packet type so if we got a SET request you know to update your outputs
-bool CMRI::process()
+// returns the packet type (CMRI::INIT, CMRI::SET or CMRI::POLL) so if we got a
+// SET request you know to update your outputs, or NULL if no valid packet was
+// received
+char CMRI::process()
 {
 	while (_serial.available() > 0)
 	{
 		if (process_char(_serial.read()))
 		{
-			return true;
+			return _rx_packet_type;
 		}
 	}
-	return false;
+	return NOOP;
 }
 
 bool CMRI::process_char(char c)

--- a/src/CMRI.h
+++ b/src/CMRI.h
@@ -36,7 +36,7 @@ class CMRI
 	void set_address(unsigned int address);
 	void set_init_handler(void (*handler)(const uint8_t *data, int len));
 
-	bool process();
+	char process();
 	bool process_char(char c);
 	void transmit();
 


### PR DESCRIPTION
The readme specifically says for `process()`:
> Return value is NULL for no valid packet received, or one of CMRI::INIT, CMRI::SET, CMRI::POLL depending on the packet type received.

However in reality it's just returning `true` / `false`. For some users, having it return the processed packet type is a useful enhancement. Lets update it to match the documentation.

Note: although this is a behaviour change, anyone doing `if (cmri.process())` will see unchanged behaviour, as `false` and `NOOP` are both `0` and so equivalent.