### PR TITLE
Tolerate extra SYN bytes in preamble

### DIFF
--- a/src/CMRI.cpp
+++ b/src/CMRI.cpp
@@ -182,7 +182,7 @@ uint8_t CMRI::_decode(uint8_t c)
 	case PREAMBLE_3:
 		if (c == STX)
 			_mode = DECODE_ADDR;
-		else
+		else if (c != 0xFF)
 			_mode = PREAMBLE_1;
 		break;
 

--- a/test/test_cmri/test_main.cpp
+++ b/test/test_cmri/test_main.cpp
@@ -176,6 +176,53 @@ void test_transmit_escapes_control_bytes(void)
 	TEST_ASSERT_EQUAL_UINT8(CMRI::ETX, s.tx[10]);
 }
 
+// A third SYN byte does not desync the parser.
+void test_triple_syn_accepted(void)
+{
+	Stream s;
+	CMRI cmri(0, 24, 48, s);
+
+	cmri.set_byte(0, 0x42);
+
+	s.feed(0xFF); // third SYN
+	feed_packet(s, 0, CMRI::POLL, nullptr, 0);
+	TEST_ASSERT_TRUE(cmri.process());
+	TEST_ASSERT_EQUAL_UINT8(0x42, s.tx[5]);
+}
+
+// Four SYN bytes are tolerated.
+void test_quad_syn_accepted(void)
+{
+	Stream s;
+	CMRI cmri(0, 24, 48, s);
+
+	cmri.set_byte(0, 0x99);
+
+	s.feed(0xFF); // third SYN
+	s.feed(0xFF); // fourth SYN
+	feed_packet(s, 0, CMRI::POLL, nullptr, 0);
+	TEST_ASSERT_TRUE(cmri.process());
+	TEST_ASSERT_EQUAL_UINT8(0x99, s.tx[5]);
+}
+
+// A 0xFF byte inside a SET body is data, not a preamble SYN.
+void test_syn_in_body_not_resynced(void)
+{
+	Stream s;
+	CMRI cmri(0, 24, 48, s);
+
+	uint8_t data[6] = {0xFF, 0x00, 0x00, 0x00, 0x00, 0x00};
+	feed_packet(s, 0, CMRI::SET, data, 6);
+	TEST_ASSERT_TRUE(cmri.process());
+
+	TEST_ASSERT_EQUAL_UINT8(0xFF, cmri.get_byte(0));
+
+	cmri.set_byte(0, 0xAA);
+	feed_packet(s, 0, CMRI::POLL, nullptr, 0);
+	TEST_ASSERT_TRUE(cmri.process());
+	TEST_ASSERT_EQUAL_UINT8(0xAA, s.tx[5]);
+}
+
 // Garbage before a valid packet is resynced away by the preamble state machine.
 void test_preamble_resync_after_garbage(void)
 {
@@ -205,6 +252,9 @@ int main(int, char **)
 	RUN_TEST(test_set_packet_updates_outputs);
 	RUN_TEST(test_address_filtering);
 	RUN_TEST(test_transmit_escapes_control_bytes);
+	RUN_TEST(test_triple_syn_accepted);
+	RUN_TEST(test_quad_syn_accepted);
+	RUN_TEST(test_syn_in_body_not_resynced);
 	RUN_TEST(test_preamble_resync_after_garbage);
 	return UNITY_END();
 }


### PR DESCRIPTION
As reported in issue #28:

### [BUG] A third SYN byte desyncs the preamble and drops the frame
- Status: **still present in v1.7.0** (unchanged logic).
- Spec: LCS-9.10.1 p.3 ("A message starts with two SYN ... characters provide data receivers to synchronize"), p.5 §D.
- Code: src/CMRI.cpp:175-187 (`PREAMBLE_2`, `PREAMBLE_3`).
- In `PREAMBLE_3`, any byte other than STX — including another 0xFF — resets to `PREAMBLE_1`. So the sequence `FF FF FF 02 ...` is rejected: the third 0xFF falls to the `else` branch, and the following STX is then discarded in `PREAMBLE_1`. The spec specifies exactly two SYNs, so a strictly conforming host (JMRI) works, but SYN is explicitly a *synchronization/idle* character; hosts or converters that pad with extra 0xFF (or line idle reading as 0xFF after a break) make every frame invisible to this node. The v1.7.0 test suite's resync test (test/test_cmri/test_main.cpp:180-195) covers a *lone* 0xFF in garbage but not the triple-SYN case, so this remains untested upstream.
- Failure scenario: a master that transmits 3+ SYNs for receiver settling (common on RS-485 with slow-enabling drivers) gets zero responses from this node, ever.
- Fix: in `PREAMBLE_3`, `if (c == 0xFF) stay in PREAMBLE_3;` before the STX/else tests.

This PR implements the required fix and adds corresponding tests.