### PR TITLE
Add configurable transmit delay via set_transmit_delay()

### DIFF
--- a/examples/init_handler_with_delay/init_handler_with_delay.ino
+++ b/examples/init_handler_with_delay/init_handler_with_delay.ino
@@ -1,23 +1,25 @@
 /**
- * C/MRI INIT handler example
- * ===========================
- * Demonstrates how to register an INIT callback to inspect the
- * configuration payload sent by JMRI at startup.
+ * C/MRI INIT handler with transmit delay example
+ * ================================================
+ * Demonstrates how to register an INIT callback that parses the
+ * transmit delay (dH/dL) from the INIT payload and applies it
+ * using set_transmit_delay().
  *
  * The INIT message body follows NMRA LCS-9.10.1:
  *   byte 0:   NDP (Node Definition Parameter)
- *   bytes 1-2: DLH/DLL (transmit delay, high & low bytes)
+ *   bytes 1-2: dH/dL (transmit delay, high & low bytes)
  *   bytes 3+:  node-type-specific options
  *
- * The transmit delay is computed as (DLH * 256 + DLL) * 10 microseconds.
- * This example reads the delay and prints the configuration to Serial.
+ * The transmit delay is computed as (dH * 256 + dL) * 10 microseconds.
+ * Modern hosts set dH/dL to zero; non-zero values are for legacy
+ * compatibility. This delay is applied before each GET (R) reply to
+ * allow RS-485 transceiver turnaround.
  *
  * To set up in JMRI:
  * 1: Create a new C/MRI connection (Serial, 9600 baud)
  * 2: Configure a node with address 0 — JMRI sends an INIT at startup
  * 3: Open Tools > Tables > Lights and add a light at address 1
  * 4: Open the C/MRI Monitor to watch the INIT message
- *    Raw format: [41 49 43 00 0A ...] = UA 'A', cmd 'I', NDP='C', DL=10
  *
  * Wiring:
  *   Serial (pins 0/1) -> RS-485 transceiver -> host (JMRI)
@@ -32,9 +34,7 @@ CMRI cmri;                      // defaults to a SMINI with address 0, using Ser
 
 // ---------------------------------------------------------------------------
 // INIT handler callback
-// Called automatically when an INIT ('I') packet is received.
-// data  – pointer to the raw INIT payload bytes
-// len   – number of bytes in the payload
+// Parses dH/dL and applies the transmit delay via set_transmit_delay().
 // ---------------------------------------------------------------------------
 void on_init(const uint8_t *data, int len)
 {
@@ -49,24 +49,15 @@ void on_init(const uint8_t *data, int len)
 
 	if (len >= 3)
 	{
-		int delay_us = (data[1] * 256 + data[2]) * 10;
+		unsigned int dH = data[1];
+		unsigned int dL = data[2];
+		unsigned int delay_us = (dH * 256 + dL) * 10;
+
+		cmri.set_transmit_delay(delay_us);
+
 		console.print(F("DL="));
 		console.print(delay_us);
-		console.print(F("us "));
-	}
-
-	if (len > 3)
-	{
-		console.print(F("options="));
-		for (int i = 3; i < len; i++)
-		{
-			if (i > 3)
-				console.print(F(" "));
-			if (data[i] < 16)
-				console.print(F("0"));
-			console.print(data[i], HEX);
-		}
-		console.print(F(" "));
+		console.print(F("us applied "));
 	}
 
 	console.print(len);

--- a/src/CMRI.cpp
+++ b/src/CMRI.cpp
@@ -39,7 +39,7 @@ CMRI::CMRI(unsigned int address, unsigned int input_bits, unsigned int output_bi
 
       // parsing state
       ,
-      _mode(PREAMBLE_1), _rx_index(0), _rx_data_len(0), _init_handler(nullptr)
+      _mode(PREAMBLE_1), _rx_index(0), _rx_data_len(0), _init_handler(nullptr), _transmit_delay_us(TRANSMIT_DELAY_US)
 
 {
 	// clear to zero
@@ -57,6 +57,11 @@ void CMRI::set_address(unsigned int address)
 void CMRI::set_init_handler(void (*handler)(const uint8_t *, int))
 {
 	_init_handler = handler;
+}
+
+void CMRI::set_transmit_delay(unsigned int delay_us)
+{
+	_transmit_delay_us = delay_us;
 }
 
 // reads in serial data, decodes packets
@@ -144,7 +149,7 @@ bool CMRI::set_byte(int pos, char b)
 
 void CMRI::transmit()
 {
-	delayMicroseconds(50); // a minscule delay to let things recover
+	delayMicroseconds(_transmit_delay_us);
 	_serial.write(255);
 	_serial.write(255);
 	_serial.write(STX);

--- a/src/CMRI.h
+++ b/src/CMRI.h
@@ -35,6 +35,7 @@ class CMRI
 	CMRI(unsigned int address = 0, unsigned int input_bits = 24, unsigned int output_bits = 48, Stream &serial_class = Serial);
 	void set_address(unsigned int address);
 	void set_init_handler(void (*handler)(const uint8_t *data, int len));
+	void set_transmit_delay(unsigned int delay_us);
 
 	bool process();
 	bool process_char(char c);
@@ -85,12 +86,20 @@ class CMRI
 	char *_tx_buffer;
 	int _rx_data_len;
 	void (*_init_handler)(const uint8_t *, int);
+	unsigned int _transmit_delay_us;
 
 	Stream &_serial;
 
 	// parsing state variables
 	int _mode;
 	int _rx_index;
+
+#ifndef TRANSMIT_DELAY_US
+// Default RS-485 turnaround delay (microseconds) before transmitting.
+// Modern hosts set dH/dL to zero; this is just for transceiver settling.
+// Override at compile time or use set_transmit_delay() at runtime.
+#define TRANSMIT_DELAY_US 50
+#endif
 
 	uint8_t _decode(uint8_t c); // process one character received from serial port
 };

--- a/test/test_cmri/test_main.cpp
+++ b/test/test_cmri/test_main.cpp
@@ -194,6 +194,19 @@ void test_preamble_resync_after_garbage(void)
 	TEST_ASSERT_EQUAL_UINT8(CMRI::GET, s.tx[4]);
 }
 
+// set_transmit_delay overrides the default transmit delay.
+void test_set_transmit_delay(void)
+{
+	Stream s;
+	CMRI cmri(0, 24, 48, s);
+
+	cmri.set_byte(0, 0x42);
+	cmri.set_transmit_delay(100);
+	cmri.transmit();
+
+	TEST_ASSERT_EQUAL_UINT8(0x42, s.tx[5]);
+}
+
 int main(int, char **)
 {
 	UNITY_BEGIN();
@@ -205,6 +218,7 @@ int main(int, char **)
 	RUN_TEST(test_set_packet_updates_outputs);
 	RUN_TEST(test_address_filtering);
 	RUN_TEST(test_transmit_escapes_control_bytes);
+	RUN_TEST(test_set_transmit_delay);
 	RUN_TEST(test_preamble_resync_after_garbage);
 	return UNITY_END();
 }


### PR DESCRIPTION
## Summary

While the v1.7.x library now supports INIT messages and allow for an init handler, it lacks a way to set the transmit delay.

NMRA CMRInet (LCS-9.10.1) specifies a per-character transmission delay derived from the dH/dL bytes in the INIT message. Each unit represents 10 microseconds. Modern hosts set dH/dL to zero; non-zero values are for legacy compatibility with older Host computers.

The library hardcodes `delayMicroseconds(50)` in `transmit()` as an RS-485 turnaround delay, regardless of the commanded dH/dL value.

This PR adds a `set_transmit_delay()` method and a compile-time default via `#define TRANSMIT_DELAY_US`, allowing sketches to configure the turnaround delay. Sketches can parse dH/dL in an init handler and apply the delay automatically for legacy host compatibility.

## Changes

### Compile-time default (`CMRI.h`)

```cpp
#ifndef TRANSMIT_DELAY_US
// RS-485 turnaround delay before transmitting (microseconds)
// Set to 0 if DE timing is handled externally
#define TRANSMIT_DELAY_US 50
#endif
```

### Runtime override (`CMRI.h`, `CMRI.cpp`)

```cpp
void set_transmit_delay(unsigned int delay_us);
```

New public method stores the delay in `_transmit_delay_us`. Applied in `transmit()` before sending the GET frame:

```cpp
void CMRI::transmit()
{
    delayMicroseconds(_transmit_delay_us);
    _serial.write(255);
    // ...
}
```

### INIT handler example (`examples/init_handler_with_delay/`)

Demonstrates parsing dH/dL from the INIT payload and applying the delay:

```cpp
void on_init(const uint8_t *data, int len)
{
    if (len >= 3)
    {
        unsigned int delay_us = (data[1] * 256 + data[2]) * 10;
        cmri.set_transmit_delay(delay_us);
    }
}
```

### Unit test

Added `test_set_transmit_delay` to verify the setter compiles and `transmit()` still produces a valid frame.

## Backward compatibility

- Default `TRANSMIT_DELAY_US` is 50, matching previous hardcoded behavior
- `set_transmit_delay()` is optional -- existing sketches work unchanged
- Setting delay to 0 disables the wait (for full-duplex or external DE control)
